### PR TITLE
Add an option -since-latest-release 

### DIFF
--- a/ghrn/ghrn.go
+++ b/ghrn/ghrn.go
@@ -70,11 +70,7 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 		return fmt.Errorf("compare commitse: %s..%s %+v", rls.GetTagName(), repo.GetDefaultBranch(), err)
 	}
 
-	// new commits from latest release to default branch
-	var newCommits []string
-	for _, commit := range comp.Commits {
-		newCommits = append(newCommits, commit.GetCommit().GetTree().GetSHA())
-	}
+	newCommits := commitHashes(comp.Commits)
 
 	// Iterate over all PRs
 	for {
@@ -173,4 +169,12 @@ func commitsAll(ctx context.Context, cl *github.Client, owner string, repo strin
 		commitOpt.Page = resp.NextPage
 	}
 	return list, nil
+}
+
+func commitHashes(commits []github.RepositoryCommit) []string {
+	var newCommits []string
+	for _, commit := range commits {
+		newCommits = append(newCommits, commit.GetCommit().GetTree().GetSHA())
+	}
+	return newCommits
 }

--- a/ghrn/ghrn.go
+++ b/ghrn/ghrn.go
@@ -2,9 +2,9 @@ package ghrn
 
 import (
 	"context"
-  "net/http"
 	"fmt"
-  "io"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -13,39 +13,39 @@ import (
 
 // Config describes configuration for BuildReleaseNotes.
 type Config struct {
-  // Org is the name of the GitHub organization. Required.
-  Org string
-  // Repo is the name of the GitHub repository. Required.
-  Repo string
+	// Org is the name of the GitHub organization. Required.
+	Org string
+	// Repo is the name of the GitHub repository. Required.
+	Repo string
 
-  // GitHubToken is a GitHub API access token.
-  GitHubToken string
+	// GitHubToken is a GitHub API access token.
+	GitHubToken string
 
-  // StopAt is the number of the Pull Request to stop at.
-  // Useful for building the notes of PRs since the last release, for example.
-  StopAt int
-  // IncludeCommits will include commmits messages for each PR.
-  IncludeCommits bool
+	// StopAt is the number of the Pull Request to stop at.
+	// Useful for building the notes of PRs since the last release, for example.
+	StopAt int
+	// IncludeCommits will include commmits messages for each PR.
+	IncludeCommits bool
 }
 
 // BuildReleaseNotes lists GitHub Pull Requests and writes formatted release notes
 // to the given writer.
 func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 
-  if conf.Org == "" {
-    return fmt.Errorf("Config.Org is required")
-  }
-  if conf.Repo == "" {
-    return fmt.Errorf("Config.Repo is required")
-  }
+	if conf.Org == "" {
+		return fmt.Errorf("Config.Org is required")
+	}
+	if conf.Repo == "" {
+		return fmt.Errorf("Config.Repo is required")
+	}
 
-  var httpClient *http.Client
-  if conf.GitHubToken != "" {
-    ts := oauth2.StaticTokenSource(
-      &oauth2.Token{AccessToken: conf.GitHubToken},
-    )
-    httpClient = oauth2.NewClient(ctx, ts)
-  }
+	var httpClient *http.Client
+	if conf.GitHubToken != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: conf.GitHubToken},
+		)
+		httpClient = oauth2.NewClient(ctx, ts)
+	}
 	cl := github.NewClient(httpClient)
 
 	opt := &github.PullRequestListOptions{
@@ -57,13 +57,13 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 	for {
 		prs, resp, err := cl.PullRequests.List(ctx, conf.Org, conf.Repo, opt)
 		if err != nil {
-      return fmt.Errorf("listing PRs: %s", err)
+			return fmt.Errorf("listing PRs: %s", err)
 		}
 
 		// Iterate over PRs in this page.
 		for _, pr := range prs {
 			if *pr.Number == conf.StopAt {
-        return nil
+				return nil
 			}
 			if pr.MergedAt == nil {
 				continue
@@ -78,7 +78,7 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 
 					commits, resp, err := cl.PullRequests.ListCommits(ctx, conf.Org, conf.Repo, pr.GetNumber(), commitOpt)
 					if err != nil {
-            return fmt.Errorf("listing PR commits: %s", err)
+						return fmt.Errorf("listing PR commits: %s", err)
 					}
 
 					// Iterate over commits in this page.
@@ -113,5 +113,5 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 		}
 		opt.Page = resp.NextPage
 	}
-  return nil
+	return nil
 }

--- a/ghrn/ghrn.go
+++ b/ghrn/ghrn.go
@@ -73,7 +73,7 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 	// new commits from latest release to default branch
 	var newCommits []string
 	for _, commit := range comp.Commits {
-		newCommits = append(newCommits, commit.GetSHA())
+		newCommits = append(newCommits, commit.GetCommit().GetTree().GetSHA())
 	}
 
 	// Iterate over all PRs
@@ -98,7 +98,7 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 			}
 			var prCommits []string
 			for _, commit := range commits {
-				prCommits = append(prCommits, commit.GetSHA())
+				prCommits = append(prCommits, commit.GetCommit().GetTree().GetSHA())
 			}
 
 			if conf.StopAtLatestRelease && !any(prCommits, newCommits) {

--- a/ghrn/ghrn.go
+++ b/ghrn/ghrn.go
@@ -26,8 +26,8 @@ type Config struct {
 	StopAt int
 	// IncludeCommits will include commmits messages for each PR.
 	IncludeCommits bool
-	// StopAtLatestRelease will stop at latest release commit.
-	StopAtLatestRelease bool
+	// SinceLatestRelease will only include PRs and commits merged since the latest release tag.
+	SinceLatestRelease bool
 }
 
 // BuildReleaseNotes lists GitHub Pull Requests and writes formatted release notes
@@ -101,7 +101,7 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 				prCommits = append(prCommits, commit.GetCommit().GetTree().GetSHA())
 			}
 
-			if conf.StopAtLatestRelease && !any(prCommits, newCommits) {
+			if conf.SinceLatestRelease && !any(prCommits, newCommits) {
 				// stop any new commits do not contains pr commits
 				return nil
 			}

--- a/ghrn/ghrn.go
+++ b/ghrn/ghrn.go
@@ -98,7 +98,7 @@ func BuildReleaseNotes(ctx context.Context, w io.Writer, conf Config) error {
 			}
 
 			if conf.SinceLatestRelease && !any(prCommits, newCommits) {
-				// stop any new commits do not contains pr commits
+				// Stop when a PR doesn't contain any commits from since the latest release.
 				return nil
 			}
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	flag.StringVar(&conf.Repo, "repo", conf.Repo, "Repo. (Required)")
 	flag.IntVar(&conf.StopAt, "stop-at", conf.StopAt, "PR number to stop at")
 	flag.BoolVar(&conf.IncludeCommits, "include-commits", conf.IncludeCommits, "Include commit messages")
-	flag.BoolVar(&conf.StopAtLatestRelease, "since-latest-release", conf.IncludeCommits, "Stop at latest release's commit")
+	flag.BoolVar(&conf.StopAtLatestRelease, "since-latest-release", conf.StopAtLatestRelease, "Stop at latest release's commit")
 	flag.Parse()
 
 	if conf.Org == "" {

--- a/main.go
+++ b/main.go
@@ -2,39 +2,39 @@ package main
 
 import (
 	"context"
-  "flag"
+	"flag"
 	"fmt"
 	"os"
 
-  "github.com/buchanae/github-release-notes/ghrn"
+	"github.com/buchanae/github-release-notes/ghrn"
 )
 
 func main() {
-  conf := ghrn.Config{}
+	conf := ghrn.Config{}
 
-  flag.StringVar(&conf.Org, "org", conf.Org, "Organization. (Required)")
-  flag.StringVar(&conf.Repo, "repo", conf.Repo, "Repo. (Required)")
-  flag.IntVar(&conf.StopAt, "stop-at", conf.StopAt, "PR number to stop at")
-  flag.BoolVar(&conf.IncludeCommits, "include-commits", conf.IncludeCommits, "Include commit messages")
-  flag.Parse()
+	flag.StringVar(&conf.Org, "org", conf.Org, "Organization. (Required)")
+	flag.StringVar(&conf.Repo, "repo", conf.Repo, "Repo. (Required)")
+	flag.IntVar(&conf.StopAt, "stop-at", conf.StopAt, "PR number to stop at")
+	flag.BoolVar(&conf.IncludeCommits, "include-commits", conf.IncludeCommits, "Include commit messages")
+	flag.Parse()
 
-  if conf.Org == "" {
-    flag.Usage()
-    fmt.Fprintln(os.Stderr, "\nError: -org is required.")
-    os.Exit(1)
-  }
-  if conf.Repo == "" {
-    flag.Usage()
-    fmt.Fprintln(os.Stderr, "\nError: -repo is required.")
-    os.Exit(1)
-  }
+	if conf.Org == "" {
+		flag.Usage()
+		fmt.Fprintln(os.Stderr, "\nError: -org is required.")
+		os.Exit(1)
+	}
+	if conf.Repo == "" {
+		flag.Usage()
+		fmt.Fprintln(os.Stderr, "\nError: -repo is required.")
+		os.Exit(1)
+	}
 
-  conf.GitHubToken = os.Getenv("GITHUB_TOKEN")
+	conf.GitHubToken = os.Getenv("GITHUB_TOKEN")
 
 	ctx := context.Background()
-  err := ghrn.BuildReleaseNotes(ctx, os.Stdout, conf)
-  if err != nil {
-    fmt.Fprintln(os.Stderr, "Error: " + err.Error())
-    os.Exit(1)
-  }
+	err := ghrn.BuildReleaseNotes(ctx, os.Stdout, conf)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	flag.StringVar(&conf.Repo, "repo", conf.Repo, "Repo. (Required)")
 	flag.IntVar(&conf.StopAt, "stop-at", conf.StopAt, "PR number to stop at")
 	flag.BoolVar(&conf.IncludeCommits, "include-commits", conf.IncludeCommits, "Include commit messages")
+	flag.BoolVar(&conf.StopAtLatestRelease, "since-latest-release", conf.IncludeCommits, "Stop at latest release's commit")
 	flag.Parse()
 
 	if conf.Org == "" {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	flag.StringVar(&conf.Repo, "repo", conf.Repo, "Repo. (Required)")
 	flag.IntVar(&conf.StopAt, "stop-at", conf.StopAt, "PR number to stop at")
 	flag.BoolVar(&conf.IncludeCommits, "include-commits", conf.IncludeCommits, "Include commit messages")
-	flag.BoolVar(&conf.StopAtLatestRelease, "since-latest-release", conf.StopAtLatestRelease, "Stop at latest release's commit")
+	flag.BoolVar(&conf.SinceLatestRelease, "since-latest-release", conf.SinceLatestRelease, "Stop at latest release's commit")
 	flag.Parse()
 
 	if conf.Org == "" {

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,13 @@ github-release-notes -org ohsu-comp-bio -repo funnel -stop-at 513
 - PR #514 build: fix release notes command
 ```
 
+You can generating notes with PR that not included latest release:
+```
+github-release-notes -org ohsu-comp-bio -repo funnel -since-latest-release 
+- PR #594 cmd/worker: run task from file
+- PR #593 storage/ftp: add FTP support
+```
+
 You can include the git commit messages for each PR:
 ```
 github-release-notes -org ohsu-comp-bio -repo funnel -include-commits

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ github-release-notes -org ohsu-comp-bio -repo funnel -stop-at 513
 - PR #514 build: fix release notes command
 ```
 
-You can generating notes with PR that not included latest release:
+You can generate notes for only PRs merged since the latest release:
 ```
 github-release-notes -org ohsu-comp-bio -repo funnel -since-latest-release 
 - PR #594 cmd/worker: run task from file


### PR DESCRIPTION
Hi, thank you for great tool ! 

But I wont a option that notes only new PRs.

Here, I just add a `-since-latest-release`.  
This option analyze with latest release tag, compared commit sha and pr's commits from GitHub, and stop notes already released PR automatically.